### PR TITLE
Fix bitcoincash provider

### DIFF
--- a/contents/vulti-provider.ts
+++ b/contents/vulti-provider.ts
@@ -344,7 +344,7 @@ window.vultisig = providers;
 window.cosmos = cosmosProvider;
 window.bitcoin = bitcoinProvider;
 window.litecoin = litecoinProvider;
-window.bitcoincash = litecoinProvider;
+window.bitcoincash = bitcoincashProvider;
 window.dash = dashProvider;
 window.dogecoin = dogecoinProvider;
 


### PR DESCRIPTION
Bitcoin Cash’s provider is set to Litecoin.