### PR TITLE
handles ETH_GET_TRANSACTION_BY_HASH case in handleRequest

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -366,7 +366,8 @@ const handleRequest = (
 
         break;
       }
-      case RequestMethod.VULTISIG.GET_TRANSACTION_BY_HASH: {
+      case RequestMethod.VULTISIG.GET_TRANSACTION_BY_HASH: 
+      case RequestMethod.METAMASK.ETH_GET_TRANSACTION_BY_HASH: {
         if (Array.isArray(params)) {
           const [hash] = params;
 


### PR DESCRIPTION
Fix for the following error:
```
index.js:74 Error: invalid value for value.hash (invalid hash (argument="value", value=null, code=INVALID_ARGUMENT, version=6.13.5)) (value={ "error": "Unsupported method: eth_getTransactionByHash" }, code=BAD_DATA, version=6.13.5)
    at makeError (chunk-FOXDCRSO.js?v=e0ba3cbf:325:15)
    at assert (chunk-FOXDCRSO.js?v=e0ba3cbf:338:11)
    at chunk-FOXDCRSO.js?v=e0ba3cbf:15865:9
    at formatTransactionResponse (chunk-FOXDCRSO.js?v=e0ba3cbf:16016:5)
    at BrowserProvider._wrapTransactionResponse (chunk-FOXDCRSO.js?v=e0ba3cbf:17100:36)
    at BrowserProvider.getTransaction (chunk-FOXDCRSO.js?v=e0ba3cbf:17434:17)
    at async checkTx (chunk-FOXDCRSO.js?v=e0ba3cbf:18600:23)
```